### PR TITLE
clamped cursor, improved backspace

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 This is a list of known issues.
 * For some reason some garbage text like `q^G^A` will randomly appear while writing in EDIT mode
     * This seems related to reallocation. For example if you press enter 4 times it will appear
-* You can move the cursor beyond the allocated space which can potentially let the user write to bad memory. Need to clamp the cursor to the current maximum-allocated numbers of lines.
 * When moving cursor to the middle of some text, it will overwrite the existing text rather than actually inserting it between
 * Tab characters (`\t`) are very buggy, convert tabs into spaces to make it easier to work with
 

--- a/include/screen_buffer.h
+++ b/include/screen_buffer.h
@@ -18,6 +18,9 @@ struct screen_buffer_t
 	// all lines in the buffer (e.g., entire source file)
 	char (*lines)[LINE_BUFF_SIZE];
 	size_t total_lines;
+	// the largest (occupied) line meaning the latest line with content.
+	// this is used for locking the cursor to prevent moving past our buffer
+	size_t max_occupied_line;
 	// current line index on the screen buffer (values between start_idx & end_idx)
 	size_t current_line;
 	// start index of which lines to display

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -12,6 +12,10 @@ void cursor_move_down(
 		struct cursor_t* const cursor,
 		struct screen_buffer_t* const screen)
 {
+	// prevent user from accessing unallocated space
+	if (cursor->row + 1 >= screen->max_occupied_line)
+		return;
+
 	cursor->row++;
 	screen->current_line++;
 

--- a/src/screen_buffer.c
+++ b/src/screen_buffer.c
@@ -11,6 +11,7 @@ int8_t screen_init(
 	screen->max_rows = window->rows;
 	screen->current_line = 0;
 	screen->lines = calloc(1, sizeof(*screen->lines));
+	screen->max_occupied_line = 1;
 	screen->total_lines = 1;
 	if (!screen->lines)
 		return -1;
@@ -26,7 +27,9 @@ void screen_draw(
 	{
 		move(buffer_idx++, 0);
 		clrtoeol();
-		if (strlen(screen->lines[i]) == 0)
+		if (strlen(screen->lines[i]) == 0 && i < screen->max_occupied_line)
+			printw("");
+		else if (strlen(screen->lines[i]) == 0 && i >= screen->max_occupied_line)
 			printw("~");
 		else
 			printw("%s", screen->lines[i]);


### PR DESCRIPTION
previously backspace would NOT bring the rest of the buffer up when deleting a line since we hadn't (at the time) implemented cursor movement; this has now been fixed. We're also now maintaining an iterator of the current max occupied line to clamp the cursor and prevent it from accessing unallocated space