### PR TITLE
proper backspace wrapping and mid-buffer returns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@ This is a list of known issues.
 * For some reason some garbage text like `q^G^A` will randomly appear while writing in EDIT mode
     * This seems related to reallocation. For example if you press enter 4 times it will appear
 * When moving cursor to the middle of some text, it will overwrite the existing text rather than actually inserting it between
-* When using backspace, if you move the cursor to the beginning while the buffer is not empty, it will start deleting the characters on current line instead of wrapping to the above line and copying the remaining buffer (kind of acting like the DEL key)
 
 ## Feature Requests
 This is a list of items that I eventually want to add.


### PR DESCRIPTION
previously when backspacing at the beginning of a line when the buffer was not empty, it was not moving the buffer to the end of the previous line. similarly, pressing return key in the middle of a buffer was not copying (partial) contents and moving it into the next (new) line and shifting all the other contents down.