### PR TITLE
(#25) expand tabs to spaces when reading files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This is a dummy project greatly inspired by vi(m) to help me learn the `ncurses`
 This project is still extremely young and pretty buggy, it's more so an experiment rather than to serve as full-fledged software (vim already exists, afterall).
 
 ## KNOWN ISSUES
-* Currently `ttedit` cannot render tabs (`\t`) correctly. So if you open a file with `ttedit` that was written with another editor (like vim), it will be very awkward to use.
 * Writing past 255 characters on a line exhibits some odd behaviour - this case is not properly handled
 * There is no wrapping if writing past the width of your terminal - technically the line is still written correctly but visually is akward
 * `ttedit` does not currently support dynamically resizing your terminal window, so zooming in/out will break the rendering

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 ## Feature Requests
 This is a list of items that I eventually want to add.
-* Expand tabs into spaces when reading files
 * Show the COMMAND BUFFER on the bottom of the screen (maybe towards the bottom right) to make it clearer for user to see what they're typing
 * Undo/redo (up to a maximum memory cap, e.g., 100 commands)
 * Add configuration options to allow for things like changing the default tab spaces

--- a/src/screen_buffer.c
+++ b/src/screen_buffer.c
@@ -573,6 +573,31 @@ bool screen_read_file(
 			if (current_buffer[strlen(current_buffer)-1] == '\n')
 				current_buffer[strlen(current_buffer)-1] = '\0';
 
+			// replace tabs with four spaces
+			size_t len = strlen(current_buffer);
+			char buff[LINE_BUFF_SIZE] = {0};
+			size_t offset = 0;
+			for (size_t i = 0; i < len; ++i)
+			{
+				if (current_buffer[i] == '\t')
+				{
+					strncat(buff, current_buffer + offset, i - offset);
+					strncat(buff, "    ", 5);
+					offset = i + 1;
+				}
+				else
+				{
+					strncat(buff, current_buffer + offset, 1);
+					offset++;
+				}
+			}
+
+			if (strlen(buff) > 0)
+			{
+				memset(current_buffer, 0, LINE_BUFF_SIZE);
+				memcpy(current_buffer, buff, LINE_BUFF_SIZE);
+			}
+
 			memcpy(
 					screen->lines[current_line++], 
 					current_buffer, 


### PR DESCRIPTION
for compatability purposes, expand tab characters (\t) to spaces